### PR TITLE
Support edge

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -220,7 +220,7 @@ const getCompareSnapshotsPlugin = (on, config) => {
     const width = config.viewportWidth || '1280'
     const height = config.viewportHeight || '720'
 
-    if (browser.name === 'chrome') {
+    if (browser.family === 'chromium') {
       launchOptions.args.push(`--window-size=${width},${height}`)
       launchOptions.args.push('--force-device-scale-factor=1')
     }


### PR DESCRIPTION
[Only one instance of the 'before:browser:launch' event can be registered](https://github.com/cypress-io/cypress/issues/19809), so using this library means that the 'before:browser:launch' must support all browsers. Update the browser launch args logic to support other chromium browsers, notably Edge.